### PR TITLE
Handle WeRead auth failure error code

### DIFF
--- a/weread2notionpro/weread_api.py
+++ b/weread2notionpro/weread_api.py
@@ -258,6 +258,8 @@ class WeReadApi:
             print(
                 "::error::微信读书Cookie过期了，请参考文档重新设置。https://mp.weixin.qq.com/s/B_mqLUZv7M1rmXRsMlBf7A"
             )
+        elif errcode == -2013:
+            print("::error::鉴权失败，请更新 WEREAD_COOKIE")
 
     def parse_json_response(self, response, context):
         try:


### PR DESCRIPTION
## Summary
- add a dedicated error message when the WeRead API returns errcode -2013

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68c926352a48832f8803b3a721c22eae